### PR TITLE
Api Wrapper

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,3 @@
 # Global
 **/.env
-
-# API Wrapper
-api-wrapper/*.csv
+**/*.csv

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,3 @@
 # Global
 **/.env
-**/*.csv
+api-wrapper/**/*.csv

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+# Global
+**/.env
+
+# API Wrapper
+api-wrapper/*.csv

--- a/api-wrapper/.env.example
+++ b/api-wrapper/.env.example
@@ -1,0 +1,6 @@
+# Alpaca (Stock Market API)
+API_KEY=
+API_SECRET=
+
+# Alpha Vantage (Currency Exchange API)
+ACCESS_KEY=

--- a/api-wrapper/forex.ipynb
+++ b/api-wrapper/forex.ipynb
@@ -1,0 +1,160 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "106555"
+      ]
+     },
+     "execution_count": 2,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "import os\n",
+    "from dotenv import load_dotenv\n",
+    "import requests\n",
+    "\n",
+    "load_dotenv()\n",
+    "access_key = os.getenv('ACCESS_KEY')\n",
+    "\n",
+    "# API from Alpha Vantage\n",
+    "# Limited to 25 requests/day at the free tier\n",
+    "\n",
+    "# USD to EUR\n",
+    "url = f'https://www.alphavantage.co/query?function=FX_DAILY&from_symbol=USD&to_symbol=EUR&outputsize=full&apikey={access_key}&datatype=csv'\n",
+    "\n",
+    "response = requests.get(url)\n",
+    "\n",
+    "open('eur.csv', 'wb').write(response.content)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "254872"
+      ]
+     },
+     "execution_count": 3,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# USD to JPY\n",
+    "url = f'https://www.alphavantage.co/query?function=FX_DAILY&from_symbol=USD&to_symbol=JPY&outputsize=full&apikey={access_key}&datatype=csv'\n",
+    "\n",
+    "response = requests.get(url)\n",
+    "\n",
+    "open('jpy.csv', 'wb').write(response.content)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "106555"
+      ]
+     },
+     "execution_count": 4,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# USD to AUD\n",
+    "url = f'https://www.alphavantage.co/query?function=FX_DAILY&from_symbol=USD&to_symbol=AUD&outputsize=full&apikey={access_key}&datatype=csv'\n",
+    "\n",
+    "response = requests.get(url)\n",
+    "\n",
+    "open('aud.csv', 'wb').write(response.content)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "220075"
+      ]
+     },
+     "execution_count": 5,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# USD to CAD\n",
+    "url = f'https://www.alphavantage.co/query?function=FX_DAILY&from_symbol=USD&to_symbol=CAD&outputsize=full&apikey={access_key}&datatype=csv'\n",
+    "\n",
+    "response = requests.get(url)\n",
+    "\n",
+    "open('cad.csv', 'wb').write(response.content)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "220031"
+      ]
+     },
+     "execution_count": 6,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# USD to CNY\n",
+    "url = f'https://www.alphavantage.co/query?function=FX_DAILY&from_symbol=USD&to_symbol=CNY&outputsize=full&apikey={access_key}&datatype=csv'\n",
+    "\n",
+    "response = requests.get(url)\n",
+    "\n",
+    "open('cny.csv', 'wb').write(response.content)"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.11.5"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}

--- a/api-wrapper/forex.py
+++ b/api-wrapper/forex.py
@@ -1,0 +1,44 @@
+import os
+from dotenv import load_dotenv
+import requests
+
+load_dotenv()
+access_key = os.getenv('ACCESS_KEY')
+
+# API from Alpha Vantage
+# Limited to 25 requests/day at the free tier
+
+# USD to EUR
+url = f'https://www.alphavantage.co/query?function=FX_DAILY&from_symbol=USD&to_symbol=EUR&outputsize=full&apikey={access_key}&datatype=csv'
+
+response = requests.get(url)
+
+open('eur.csv', 'wb').write(response.content)
+
+# USD to JPY
+url = f'https://www.alphavantage.co/query?function=FX_DAILY&from_symbol=USD&to_symbol=JPY&outputsize=full&apikey={access_key}&datatype=csv'
+
+response = requests.get(url)
+
+open('jpy.csv', 'wb').write(response.content)
+
+# USD to AUD
+url = f'https://www.alphavantage.co/query?function=FX_DAILY&from_symbol=USD&to_symbol=AUD&outputsize=full&apikey={access_key}&datatype=csv'
+
+response = requests.get(url)
+
+open('aud.csv', 'wb').write(response.content)
+
+# USD to CAD
+url = f'https://www.alphavantage.co/query?function=FX_DAILY&from_symbol=USD&to_symbol=CAD&outputsize=full&apikey={access_key}&datatype=csv'
+
+response = requests.get(url)
+
+open('cad.csv', 'wb').write(response.content)
+
+# USD to CNY
+url = f'https://www.alphavantage.co/query?function=FX_DAILY&from_symbol=USD&to_symbol=CNY&outputsize=full&apikey={access_key}&datatype=csv'
+
+response = requests.get(url)
+
+open('cny.csv', 'wb').write(response.content)

--- a/api-wrapper/stock.ipynb
+++ b/api-wrapper/stock.ipynb
@@ -1,0 +1,122 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import os\n",
+    "from dotenv import load_dotenv\n",
+    "from alpaca.data.historical import StockHistoricalDataClient\n",
+    "\n",
+    "load_dotenv()\n",
+    "\n",
+    "# API from Alpaca (website: https://docs.alpaca.markets/docs/getting-started)\n",
+    "# Limited to 200 calls/min at the free tier\n",
+    "client = StockHistoricalDataClient(os.getenv('API_KEY'), os.getenv('API_SECRET'))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 12,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from alpaca.data.requests import StockBarsRequest\n",
+    "from alpaca.data.timeframe import TimeFrame\n",
+    "from datetime import datetime, timedelta\n",
+    "\n",
+    "def stock_info_from_range(symbols: list[str], start: datetime, end: datetime):\n",
+    "  request_params = StockBarsRequest(\n",
+    "    symbol_or_symbols=symbols,\n",
+    "    timeframe=TimeFrame.Day,\n",
+    "    start=start,\n",
+    "    end=end\n",
+    "  )\n",
+    "\n",
+    "  apple_bars = client.get_stock_bars(request_params)\n",
+    "\n",
+    "  return apple_bars.df\n",
+    "\n",
+    "def stock_info_from_day(symbols: list[str], day: datetime):\n",
+    "  end = day + timedelta(days=1)\n",
+    "\n",
+    "  request_params = StockBarsRequest(\n",
+    "    symbol_or_symbols=symbols,\n",
+    "    timeframe=TimeFrame.Day,\n",
+    "    start=day,\n",
+    "    end=end\n",
+    "  )\n",
+    "\n",
+    "  apple_bars = client.get_stock_bars(request_params)\n",
+    "\n",
+    "  return apple_bars.df"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 19,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "                                    open    high       low   close  \\\n",
+      "symbol timestamp                                                     \n",
+      "AAPL   2024-01-17 05:00:00+00:00  181.27  182.93  180.3000  182.68   \n",
+      "       2024-01-18 05:00:00+00:00  186.09  189.14  185.8300  188.63   \n",
+      "       2024-01-19 05:00:00+00:00  189.33  191.95  188.8200  191.56   \n",
+      "       2024-01-22 05:00:00+00:00  192.30  195.33  192.2600  193.89   \n",
+      "       2024-01-23 05:00:00+00:00  195.02  195.75  193.8299  195.18   \n",
+      "\n",
+      "                                      volume  trade_count        vwap  \n",
+      "symbol timestamp                                                       \n",
+      "AAPL   2024-01-17 05:00:00+00:00  47321545.0     594725.0  181.920124  \n",
+      "       2024-01-18 05:00:00+00:00  78031784.0     787472.0  187.937675  \n",
+      "       2024-01-19 05:00:00+00:00  68902985.0     682664.0  190.615081  \n",
+      "       2024-01-22 05:00:00+00:00  60139948.0     718256.0  193.989116  \n",
+      "       2024-01-23 05:00:00+00:00  42360151.0     533198.0  194.820338  \n",
+      "                                     open    high     low   close      volume  \\\n",
+      "symbol timestamp                                                                \n",
+      "AAPL   2024-02-01 05:00:00+00:00  183.985  186.95  183.82  186.86  64885408.0   \n",
+      "\n",
+      "                                  trade_count        vwap  \n",
+      "symbol timestamp                                           \n",
+      "AAPL   2024-02-01 05:00:00+00:00     820977.0  185.568846  \n"
+     ]
+    }
+   ],
+   "source": [
+    "# Example calls\n",
+    "df = stock_info_from_range(['AAPL'], start=datetime(2024, 1, 17), end=datetime(2024, 1, 24))\n",
+    "print(df.head())\n",
+    "\n",
+    "df = stock_info_from_day(['AAPL'], datetime(2024, 2, 1))\n",
+    "print(df.head())"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.11.5"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}

--- a/api-wrapper/stock.py
+++ b/api-wrapper/stock.py
@@ -1,0 +1,45 @@
+import os
+from dotenv import load_dotenv
+from alpaca.data.historical import StockHistoricalDataClient
+from alpaca.data.requests import StockBarsRequest
+from alpaca.data.timeframe import TimeFrame
+from datetime import datetime, timedelta
+
+load_dotenv()
+
+# API from Alpaca (website: https://docs.alpaca.markets/docs/getting-started)
+# Limited to 200 calls/min at the free tier
+client = StockHistoricalDataClient(os.getenv('API_KEY'), os.getenv('API_SECRET'))
+
+def stock_info_from_range(symbols: list[str], start: datetime, end: datetime):
+  request_params = StockBarsRequest(
+    symbol_or_symbols=symbols,
+    timeframe=TimeFrame.Day,
+    start=start,
+    end=end
+  )
+
+  apple_bars = client.get_stock_bars(request_params)
+
+  return apple_bars.df
+
+def stock_info_from_day(symbols: list[str], day: datetime):
+  end = day + timedelta(days=1)
+
+  request_params = StockBarsRequest(
+    symbol_or_symbols=symbols,
+    timeframe=TimeFrame.Day,
+    start=day,
+    end=end
+  )
+
+  apple_bars = client.get_stock_bars(request_params)
+
+  return apple_bars.df
+
+# Example calls
+# df = stock_info_from_range(['AAPL'], start=datetime(2024, 1, 17), end=datetime(2024, 1, 24))
+# print(df.head())
+
+# df = stock_info_from_day(['AAPL'], datetime(2024, 2, 1))
+# print(df.head())


### PR DESCRIPTION
## Added 2 Files
- api-wrapper/forex.ipynb
  - Grabs historical and current (within a day) currency exchange rate data from the top 5 most used currencies from the past 20 years and stores them in CSV files
  - Uses Alpha Vantage API, which is limited to 25 requests/day
- api-wrapper/stock.ipynb
  - Provides functions to get historical and current (within a day) stock market information about specified stock tickers within a time interval
    - functions return dataframes
  - Uses Alpaca API, which is limited to 200 requests/minute